### PR TITLE
Configuração de deploy da landpage na AWS

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -1,0 +1,32 @@
+name: Deploy to AWS (Landpage)
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          npm install
+
+      - name: Build application
+        run: |
+          npm run build
+
+      - name: Deploy to AWS S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: sa-east-1
+          S3_BUCKET_NAME: mamao-landpage-tashiro
+          CF_DISTRIBUTION_ID: EE7HOT45Y65FF
+        run: |
+          aws s3 sync build/ s3://${S3_BUCKET_NAME}/ --delete
+          aws cloudfront create-invalidation --distribution-id ${CF_DISTRIBUTION_ID} --paths "/*"


### PR DESCRIPTION
# Fluxo de Deploy da Aplicação React para AWS S3 e CloudFront

Esse fluxo de github action realiza o deploy da aplicação React para um bucket S3 da AWS e invalida a distribuição CloudFront para garantir a atualização da aplicação. 

## Pré-requisitos

Antes de rodar esse fluxo, é necessário:

- Configurar o AWS CLI com as credenciais corretas
- Ter um bucket S3 já criado na sua conta AWS
- Ter uma distribuição CloudFront já criada na sua conta AWS

## Inputs

Esse fluxo aceita os seguintes inputs:

- `aws-region`: Região da AWS onde o bucket S3 e a distribuição CloudFront foram criados
- `s3-bucket-name`: Nome do bucket S3 onde a aplicação React será armazenada
- `cloudfront-distribution-id`: ID da distribuição CloudFront a ser invalidada

## Outputs

Esse fluxo não produz outputs.

## Exemplo de Uso

Esse é um exemplo de como usar esse fluxo:

```yaml
name: Deploy React App to S3 and CloudFront

on:
  push:
    branches:
      - main

jobs:
  deploy:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
      - name: Setup Node.js
        uses: actions/setup-node@v1
        with:
          node-version: '14.x'
      - name: Install Dependencies
        run: npm ci
      - name: Build
        run: npm run build
      - name: Deploy to S3 and Invalidate CloudFront
        uses: path-to-deploy-action
        with:
          aws-region: us-east-1
          s3-bucket-name: my-bucket
          cloudfront-distribution-id: 1234567890
        env:
          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
